### PR TITLE
Fixed shared client balance subscription handling

### DIFF
--- a/HTX.Net/Clients/SpotApi/HTXSocketClientSpotApiShared.cs
+++ b/HTX.Net/Clients/SpotApi/HTXSocketClientSpotApiShared.cs
@@ -1,8 +1,8 @@
-﻿using HTX.Net.Interfaces.Clients.SpotApi;
+﻿using CryptoExchange.Net.Objects.Sockets;
 using CryptoExchange.Net.SharedApis;
-using CryptoExchange.Net.Objects.Sockets;
-using HTX.Net.Objects.Models.Socket;
 using HTX.Net.Enums;
+using HTX.Net.Interfaces.Clients.SpotApi;
+using HTX.Net.Objects.Models.Socket;
 
 namespace HTX.Net.Clients.SpotApi
 {
@@ -132,7 +132,7 @@ namespace HTX.Net.Clients.SpotApi
 
             var result = await SubscribeToAccountUpdatesAsync(
                 update => handler(update.AsExchangeEvent<IEnumerable<SharedBalance>>(Exchange, new[] { new SharedBalance(update.Data.Asset, update.Data.Available ?? 0, update.Data.Balance ?? update.Data.Available ?? 0) })),
-                ct: ct).ConfigureAwait(false);
+                2, ct: ct).ConfigureAwait(false);
 
             return new ExchangeResult<UpdateSubscription>(Exchange, result);
         }


### PR DESCRIPTION
Updated the `IBalanceSocketClient.SubscribeToBalanceUpdatesAsync()` implementation to subscribe using the mode "2". This will result in socket messages for every "Total", "Available" balance update. Each update will then include both numbers (Total, Available)

Excerpt from the docs:
```
4、Specify "mode" as 2:
accounts.update#2
Whenever account balance or available balance changed, it will be updated together.
```
(https://www.htx.com/en-us/opend/newApiPages/?id=7ec52e28-7773-11ed-9966-0242ac110003)